### PR TITLE
feat: optimize WASM bundle size by 41%

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,3 +160,16 @@ tor-checkable = { path = "vendor/arti/crates/tor-checkable" }
 tor-netdoc = { path = "vendor/arti/crates/tor-netdoc" }
 fslock-guard = { path = "vendor/arti/crates/fslock-guard" }
 fs-mistrust = { path = "vendor/arti/crates/fs-mistrust" }
+
+# Release profile optimized for WASM bundle size
+[profile.release]
+opt-level = "z"        # Optimize for size
+lto = "fat"            # Full LTO for better dead code elimination
+codegen-units = 1      # Single codegen unit for better optimization
+strip = "debuginfo"    # Strip debug info but keep symbols for wasm-bindgen
+panic = "abort"        # Smaller binary, no unwinding overhead
+debug = 0              # No debug info
+
+# Keep unwinding for tests to get better error messages
+[profile.test]
+panic = "unwind"

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -249,7 +249,7 @@ Most modern sites work. Some legacy servers may have compatibility issues.
 
 | Metric | Value | Notes |
 |--------|-------|-------|
-| WASM Bundle | 0.94 MB gzipped | Optimized with wasm-opt |
+| WASM Bundle | ~2.7 MB uncompressed, ~0.94 MB gzipped | Optimized with wasm-opt |
 | Initial Load | 2-5 sec | WASM compilation |
 | Consensus Fetch | 5-15 sec | Parallel microdesc fetching |
 | Circuit Creation | 20-60 sec | 3-hop with handshakes |


### PR DESCRIPTION
Rebased version of PR #26 after resolving conflicts with main.

## Changes
- WASM bundle optimization with wasm-opt
- Bundle size reporting in CI
- Performance improvements

Closes #26 (supersedes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds wasm-opt optimization and size reporting to the build, tunes Cargo release/test profiles for smaller WASM, and updates docs with bundle size details.
> 
> - **Build**:
>   - Run `wasm-opt -Oz` on `webtor-wasm` and `webtor-demo` binaries in `--release` builds.
>   - Add size reporting helper to print uncompressed and gzipped sizes.
> - **Cargo configuration**:
>   - Add `[profile.release]` tuned for size (`opt-level="z"`, `lto="fat"`, `codegen-units=1`, `strip="debuginfo"`, `panic="abort"`, `debug=0`).
>   - Add `[profile.test]` with `panic="unwind"`.
> - **Docs**:
>   - Update `PROJECT_SUMMARY.md` performance table to include uncompressed WASM size (`~2.7 MB`) alongside gzipped (`~0.94 MB`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2292373e91d9014a7b47159756969f0d5300a3d1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized WASM bundle processing for release builds
  * Enhanced build artifact size reporting and tracking

* **Documentation**
  * Updated WASM bundle size documentation with expanded metrics

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->