### PR TITLE
revert: swallow padding errors

### DIFF
--- a/vendor/arti/crates/tor-proto/src/client/circuit/padding/no_padding.rs
+++ b/vendor/arti/crates/tor-proto/src/client/circuit/padding/no_padding.rs
@@ -86,14 +86,10 @@ impl<S: SleepProvider> PaddingController<S> {
     pub(crate) fn decrypted_data(&self, _hop: HopNum) {}
 
     /// Report that we have decrypted a padding cell from our queue.
-    ///
-    /// In webtor-rs, we silently drop unexpected padding cells instead of treating
-    /// them as an error. This provides forward compatibility with future Tor
-    /// network behavior without requiring full maybenot integration.
     pub(crate) fn decrypted_padding(&self, _hop: HopNum) -> Result<(), crate::Error> {
-        // Silently ignore padding cells - provides receive-only tolerance
-        // without the bandwidth overhead of sending padding ourselves.
-        Ok(())
+        Err(crate::Error::CircProto(
+            "Received unexpected padding when circuit padding was not enabled.".into(),
+        ))
     }
 }
 


### PR DESCRIPTION
This PR removes what appears to be an unnecessary modification in our copy of Arti.

My current goal is to find the minimal change in Arti that is actually needed, to minimize friction in getting those changes merged into Arti.

Without this PR, this change to silently ignore padding cells (even if we improved it by making it wasm-only or some other conditional compilation), would rightly raise concern for the Arti project.

It's my understanding that we do not negotiate padding, and therefore should not receive padding. If we do receive padding then, that is legitimately an error.

My guess is that this appeared helpful earlier in development, possibly because the negotiation was not correct, but now that everything is working, the change is no longer needed, but this was not caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced circuit padding validation to properly report unexpected padding when the feature is disabled, rather than silently ignoring it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->